### PR TITLE
Remove http-php/httplug package dependancy to allow use of new API cl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GOV.UK Notify PHP client
 
+##Forked by Steven Taylor for PSR-7 updates
+##Original project at [https://github.com/alphagov/notifications-php-client](https://github.com/alphagov/notifications-php-client)
+
 Use this client to send emails, text messages and letters using the [GOV.UK Notify](https://www.notifications.service.gov.uk) API.
 
 Useful links:

--- a/composer2.json
+++ b/composer2.json
@@ -13,6 +13,7 @@
     "php": ">=5.4",
     "firebase/php-jwt": "^3.0",
     "psr/http-message": "^1.0",
+    "psr/http-client": "^1.0",
     "guzzlehttp/psr7" : "^1.2",
     "php-http/client-implementation": "^1.0"
   },

--- a/spec/integration/ClientSpec.php
+++ b/spec/integration/ClientSpec.php
@@ -11,7 +11,6 @@ use Alphagov\Notifications\Exception\UnexpectedValueException;
 use Alphagov\Notifications\Exception\ApiException;
 
 use GuzzleHttp\Psr7\Uri;
-use Http\Client\HttpClient as HttpClientInterface;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 

--- a/spec/unit/ClientSpec.php
+++ b/spec/unit/ClientSpec.php
@@ -9,7 +9,7 @@ use Alphagov\Notifications\Client;
 use Alphagov\Notifications\Exception as NotifyException;
 
 use GuzzleHttp\Psr7\Uri;
-use Http\Client\HttpClient as HttpClientInterface;
+use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,10 +1,10 @@
 <?php
 namespace Alphagov\Notifications;
 
-use GuzzleHttp\Psr7\Uri;                            // Concrete PSR-7 URL representation.
-use GuzzleHttp\Psr7\Request;                        // Concrete PSR-7 HTTP Request
-use Psr\Http\Message\ResponseInterface;             // PSR-7 HTTP Response Interface
-use Http\Client\HttpClient as HttpClientInterface;  // Interface for a PSR-7 compatible HTTP Client.
+use GuzzleHttp\Psr7\Uri;                                     // Concrete PSR-7 URL representation.
+use GuzzleHttp\Psr7\Request;                                 // Concrete PSR-7 HTTP Request
+use Psr\Http\Message\ResponseInterface;                      // PSR-7 HTTP Response Interface
+use Psr\Http\Client\ClientInterface as HttpClientInterface;  // Interface for a PSR-7 compatible HTTP Client.
 
 use Alphagov\Notifications\Authentication\JWTAuthenticationInterface;
 
@@ -25,7 +25,7 @@ class Client {
      * @const string Current version of this client.
      * This follows Semantic Versioning (http://semver.org/)
      */
-    const VERSION = '1.9.0';
+    const VERSION = '2.0.0';
 
     /**
      * @const string The API endpoint for Notify production.


### PR DESCRIPTION
Removed the client's dependancy on the php-http/httplug package and allowed the Client class to use Psr\Http\Client\ClientInterface for HTTP clients instead of the deprecated Http\Client\HttpClient